### PR TITLE
update old-ethermint-docker-compose.yml to not use static genesis.json

### DIFF
--- a/docker/old-ethermint-docker-compose.yml
+++ b/docker/old-ethermint-docker-compose.yml
@@ -8,7 +8,6 @@ services:
       - HOME_DIR=/ethermint
     command: [
             "ethermintd", "start",
-            "--home", "/ethermint",
             "--optimint.aggregator", "true",
             "--optimint.block_time", "30s",
             "--optimint.namespace_id", "0000DEADBEEF0000",
@@ -19,8 +18,6 @@ services:
             "--json-rpc.api", "eth,txpool,personal,net,web3,miner",
             "--json-rpc.address", "0.0.0.0:8545",
              ]
-    volumes:
-      - ${PWD}/ethermint/genesis.json:/ethermint/config/genesis.json:ro
     ports:
       # Expose the EVM json-rpc server
       - 8545:8545


### PR DESCRIPTION
The ghcr.io/celestiaorg/ethermint:pre-v0.2.0 image doesn't have the changes from https://github.com/celestiaorg/ethermint/commit/f843b79de1f58dd1db806a54345c86f95865c6c8 so it cannot use a static genesis file. 